### PR TITLE
add script to create defined style droplets

### DIFF
--- a/CreateStyleDroplets.applescript
+++ b/CreateStyleDroplets.applescript
@@ -15,10 +15,10 @@ use framework "Foundation"
 -- CRITICAL -- continued lines must end with ampersand plus OPT+RETURN
 --
 property styleDroplets : {formatting:"filler"} & Â
-	{logo_over_light:"-ol -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png"} & Â
-	{logo_over_light_drop:"-ol -d -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png"} & Â
-	{logo_over_light_pic:"-ol -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png"} & Â
-	{logo_over_light_drop_pic:"-ol -d -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png"} & Â
+	{logo_over_light:"-ol -mc=#ffffff -g=southeast -w=~/Pictures/watermark_light.png"} & Â
+	{logo_over_light_drop:"-ol -d -mc=#ffffff -g=southeast -w=~/Pictures/watermark_light.png"} & Â
+	{logo_over_light_pic:"-ol -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_light.png"} & Â
+	{logo_over_light_drop_pic:"-ol -d -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_light.png"} & Â
 	{formatting:"filler"} & Â
 	{logo_over_dark:"-ol -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png"} & Â
 	{logo_over_dark_drop:"-ol -d -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png"} & Â

--- a/CreateStyleDroplets.applescript
+++ b/CreateStyleDroplets.applescript
@@ -1,7 +1,7 @@
 --
 -- Original: Walter Rowe in 2022
 --
--- Create all the style droplets for every defined style in optionsList
+-- Create all the style droplets for every defined style in styleDroplets
 --
 
 use AppleScript version "2.7"
@@ -14,46 +14,46 @@ use framework "Foundation"
 --
 -- CRITICAL -- continued lines must end with ampersand plus OPT+RETURN
 --
-property optionsList : {formatting:"filler"} & Â
-	{logo_over_white:"-ol -mc=#ffffff -g=southeast -w=~/Pictures/watermark_white.png"} & Â
-	{logo_over_white_drop:"-ol -d -mc=#ffffff -g=southeast -w=~/Pictures/watermark_white.png"} & Â
-	{logo_over_white_pic:"-ol -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_white.png"} & Â
-	{logo_over_white_drop_pic:"-ol -d -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_white.png"} & Â
+property styleDroplets : {formatting:"filler"} & Â
+	{logo_over_light:"-ol -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png"} & Â
+	{logo_over_light_drop:"-ol -d -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png"} & Â
+	{logo_over_light_pic:"-ol -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png"} & Â
+	{logo_over_light_drop_pic:"-ol -d -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png"} & Â
 	{formatting:"filler"} & Â
-	{logo_over_gray:"-ol -mc=#383838 -g=southeast -w=~/Pictures/watermark_white.png"} & Â
-	{logo_over_gray_drop:"-ol -d -mc=#383838 -g=southeast -w=~/Pictures/watermark_white.png"} & Â
-	{logo_over_gray_pic:"-ol -p -mc=#383838 -g=southeast -w=~/Pictures/watermark_white.png"} & Â
-	{logo_over_gray_drop_pic:"-ol -d -p -mc=#383838 -g=southeast -w=~/Pictures/watermark_white.png"} & Â
+	{logo_over_dark:"-ol -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png"} & Â
+	{logo_over_dark_drop:"-ol -d -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png"} & Â
+	{logo_over_dark_pic:"-ol -p -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png"} & Â
+	{logo_over_dark_drop_pic:"-ol -d -p -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png"} & Â
 	{formatting:"filler"} & Â
-	{logo_white:"-l -mc=#ffffff -w=~/Pictures/watermark_gray.png"} & Â
-	{logo_white_drop:"-l -d -mc=#ffffff -w=~/Pictures/watermark_gray.png"} & Â
-	{logo_white_pic:"-l -p -mc=#ffffff -w=~/Pictures/watermark_gray.png"} & Â
-	{logo_white_drop_pic:"-l -d -p -mc=#ffffff -w=~/Pictures/watermark_gray.png"} & Â
+	{logo_light:"-l -mc=#ffffff -w=~/Pictures/watermark_dark.png"} & Â
+	{logo_light_drop:"-l -d -mc=#ffffff -w=~/Pictures/watermark_dark.png"} & Â
+	{logo_light_pic:"-l -p -mc=#ffffff -w=~/Pictures/watermark_dark.png"} & Â
+	{logo_light_drop_pic:"-l -d -p -mc=#ffffff -w=~/Pictures/watermark_dark.png"} & Â
 	{formatting:"filler"} & Â
-	{logo_gray:"-l -mc=#383838 -w=~/Pictures/watermark_white.png"} & Â
-	{logo_gray_drop:"-l -d -mc=#383838 -w=~/Pictures/watermark_white.png"} & Â
-	{logo_gray_pic:"-l -p -mc=#383838 -w=~/Pictures/watermark_white.png"} & Â
-	{logo_gray_drop_pic:"-l -d -p -mc=#383838 -w=~/Pictures/watermark_white.png"} & Â
+	{logo_dark:"-l -mc=#383838 -w=~/Pictures/watermark_light.png"} & Â
+	{logo_dark_drop:"-l -d -mc=#383838 -w=~/Pictures/watermark_light.png"} & Â
+	{logo_dark_pic:"-l -p -mc=#383838 -w=~/Pictures/watermark_light.png"} & Â
+	{logo_dark_drop_pic:"-l -d -p -mc=#383838 -w=~/Pictures/watermark_light.png"} & Â
 	{formatting:"filler"} & Â
-	{text_over_white:"-ot -mc=#ffffff -g=south -d -tc=#E0E0E0"} & Â
-	{text_over_white_drop:"-ot -d -mc=#ffffff -g=south -d -tc=#E0E0E0"} & Â
-	{text_over_white_pic:"-ot -p -mc=#ffffff -g=south -d -tc=#E0E0E0"} & Â
-	{text_over_white_drop_pic:"-ot -d -p -mc=#ffffff -g=south -d -tc=#E0E0E0"} & Â
+	{text_over_light:"-ot -mc=#ffffff -g=south -d -tc=#E0E0E0"} & Â
+	{text_over_light_drop:"-ot -d -mc=#ffffff -g=south -d -tc=#E0E0E0"} & Â
+	{text_over_light_pic:"-ot -p -mc=#ffffff -g=south -d -tc=#E0E0E0"} & Â
+	{text_over_light_drop_pic:"-ot -d -p -mc=#ffffff -g=south -d -tc=#E0E0E0"} & Â
 	{formatting:"filler"} & Â
-	{text_over_gray:"-ot -mc=#383838 -g=south -d -tc=#E0E0E0"} & Â
-	{text_over_gray_drop:"-ot -d -mc=#383838 -g=south -d -tc=#E0E0E0"} & Â
-	{text_over_gray_pic:"-ot -p -mc=#383838 -g=south -d -tc=#E0E0E0"} & Â
-	{text_over_gray_drop_pic:"-ot -d -p -mc=#383838 -g=south -d -tc=#E0E0E0"} & Â
+	{text_over_dark:"-ot -mc=#383838 -g=south -d -tc=#E0E0E0"} & Â
+	{text_over_dark_drop:"-ot -d -mc=#383838 -g=south -d -tc=#E0E0E0"} & Â
+	{text_over_dark_pic:"-ot -p -mc=#383838 -g=south -d -tc=#E0E0E0"} & Â
+	{text_over_dark_drop_pic:"-ot -d -p -mc=#383838 -g=south -d -tc=#E0E0E0"} & Â
 	{formatting:"filler"} & Â
-	{text_white:"-t -mc=#ffffff -tc=#383838"} & Â
-	{text_white_drop:"-t -d -mc=#ffffff -tc=#383838"} & Â
-	{text_white_pic:"-t -p -mc=#ffffff -tc=#383838"} & Â
-	{text_white_drop_pic:"-t -d -p -mc=#ffffff -tc=#383838"} & Â
+	{text_light:"-t -mc=#ffffff -tc=#383838"} & Â
+	{text_light_drop:"-t -d -mc=#ffffff -tc=#383838"} & Â
+	{text_light_pic:"-t -p -mc=#ffffff -tc=#383838"} & Â
+	{text_light_drop_pic:"-t -d -p -mc=#ffffff -tc=#383838"} & Â
 	{formatting:"filler"} & Â
-	{text_gray:"-t -mc=#383838 -tc=#E0E0E0"} & Â
-	{text_gray_drop:"-t -d -mc=#383838 -tc=#E0E0E0"} & Â
-	{text_gray_pic:"-t -p -mc=#383838 -tc=#E0E0E0"} & Â
-	{text_gray_drop_pic:"-t -d -p -mc=#383838 -tc=#E0E0E0"}
+	{text_dark:"-t -mc=#383838 -tc=#E0E0E0"} & Â
+	{text_dark_drop:"-t -d -mc=#383838 -tc=#E0E0E0"} & Â
+	{text_dark_pic:"-t -p -mc=#383838 -tc=#E0E0E0"} & Â
+	{text_dark_drop_pic:"-t -d -p -mc=#383838 -tc=#E0E0E0"}
 
 on sortList(theList)
 	set theIndexList to {}
@@ -80,63 +80,77 @@ end sortList
 
 on run
 	set filler to "formatting"
-	set dropletSource to "logo_white_pic.applescript"
+	set dropletSource to "logo_light_pic.applescript"
 	
-	set optionsData to my (NSDictionary's dictionaryWithDictionary:optionsList)
-	set listOfDroplets to optionsData's allKeys() as list
+	set optionsData to my (NSDictionary's dictionaryWithDictionary:styleDroplets)
+	set styleNames to optionsData's allKeys() as list
 	
-	set listOfDroplets to sortList(listOfDroplets)
+	set styleNames to sortList(styleNames)
 	
-	if listOfDroplets contains filler then
+	if styleNames contains filler then
 		set formatting to 0
-		repeat with position from 1 to count of listOfDroplets
-			if item position of listOfDroplets is filler then
+		repeat with position from 1 to count of styleNames
+			if item position of styleNames is filler then
 				set formatting to position
 			end if
 		end repeat
 		
 		if formatting is 1 then
-			set listOfDroplets to items 2 thru (count of listOfDroplets) of listOfDroplets
+			set styleNames to items 2 thru (count of styleNames) of styleNames
 		end if
-		if formatting is (count of listOfDroplets) then
-			set listOfDroplets to items 1 thru -2 of listOfDroplets
+		if formatting is (count of styleNames) then
+			set styleNames to items 1 thru -2 of styleNames
 		end if
-		if formatting is greater than 1 and formatting is less than (count of listOfDroplets) then
-			set listOfDroplets to items 1 thru (formatting - 1) of listOfDroplets & items (formatting + 1) thru (count of listOfDroplets) of listOfDroplets
+		if formatting is greater than 1 and formatting is less than (count of styleNames) then
+			set styleNames to items 1 thru (formatting - 1) of styleNames & items (formatting + 1) thru (count of styleNames) of styleNames
 		end if
 	end if
 	
-	-- select the droplet folder with Finder
+	-- select the droplet folder and droplet script with Finder 
 	set dropletFolder to POSIX path of (choose folder with prompt "Select the folder for your Magick Frames droplets:")
-	
 	set dropletSource to the quoted form of (POSIX path of (choose file with prompt "Select the Magick Frames StyleDroplet script"))
 	
-	set dropletCommands to {}
-	repeat with droplet in listOfDroplets
-		-- set destination droplet
-		set droplet to "'" & dropletFolder & droplet & ".app'"
-		-- set shell command to build droplet
-		set thisDroplet to "osacompile -x -o " & droplet & " " & dropletSource
+	-- set the initial progress bar information
+	set dropletCount to length of styleNames
+	set progress total steps to dropletCount
+	set progress completed steps to 0
+	set progress description to "Creating droplets..."
+	set progress additional description to "Preparing to process."
+	
+	repeat with dropletNum from 1 to count of styleNames
+		-- set destination droplet name
+		set dropletName to item dropletNum of styleNames
+		set droplet to "'" & dropletFolder & dropletName & ".app'"
+		
+		-- set shell command to create the droplet
+		set createDroplet to "osacompile -x -o " & droplet & " " & dropletSource
+		
+		-- Update the progress detail
+		set progress additional description to "Creating droplet " & dropletNum & " of " & dropletCount
+		
 		-- execute the shell command to build the droplet
 		try
-			do shell script thisDroplet
+			do shell script createDroplet
 		on error errStr number errorNumber
-			display dialog "Droplet ERROR: " & errStr & ": " & (errorNumber as text) & "on file " & this_filename
+			display dialog "Droplet ERROR: " & errStr & ": " & (errorNumber as text) & "on file " & droplet
 		end try
+		
+		-- Increment the progress
+		set progress completed steps to dropletNum
+		
 	end repeat
 	
-	-- join the list of droplet names on different lines
-	set AppleScript's text item delimiters to "
-"
-	set droplets to listOfDroplets as string
-	set AppleScript's text item delimiters to ""
+	-- reset all progress bar items
+	set progress total steps to 0
+	set progress completed steps to 0
+	set progress description to ""
+	set progress additional description to ""
 	
 	-- tell the user how many droplets were created, where they were created, and their names
-	display dialog "Created " & ((count of listOfDroplets) as string) & " droplets in:
-
-" & dropletFolder & "
-
-" & droplets
+	do shell script "open " & ("'" & dropletFolder & "'")
 	
+	display dialog "Created " & ((count of styleNames) as string) & " droplets in:
+
+" & dropletFolder
 	
 end run

--- a/CreateStyleDroplets.applescript
+++ b/CreateStyleDroplets.applescript
@@ -1,0 +1,142 @@
+--
+-- Original: Walter Rowe in 2022
+--
+-- Create all the style droplets for every defined style in optionsList
+--
+
+use AppleScript version "2.7"
+use scripting additions
+use framework "Foundation"
+
+--
+-- run this script to create style droplets for all of the defined styles
+-- add your own styles and re-run this script to recreate all the droplets
+--
+-- CRITICAL -- continued lines must end with ampersand plus OPT+RETURN
+--
+property optionsList : {formatting:"filler"} & Â
+	{logo_over_white:"-ol -mc=#ffffff -g=southeast -w=~/Pictures/watermark_white.png"} & Â
+	{logo_over_white_drop:"-ol -d -mc=#ffffff -g=southeast -w=~/Pictures/watermark_white.png"} & Â
+	{logo_over_white_pic:"-ol -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_white.png"} & Â
+	{logo_over_white_drop_pic:"-ol -d -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_white.png"} & Â
+	{formatting:"filler"} & Â
+	{logo_over_gray:"-ol -mc=#383838 -g=southeast -w=~/Pictures/watermark_white.png"} & Â
+	{logo_over_gray_drop:"-ol -d -mc=#383838 -g=southeast -w=~/Pictures/watermark_white.png"} & Â
+	{logo_over_gray_pic:"-ol -p -mc=#383838 -g=southeast -w=~/Pictures/watermark_white.png"} & Â
+	{logo_over_gray_drop_pic:"-ol -d -p -mc=#383838 -g=southeast -w=~/Pictures/watermark_white.png"} & Â
+	{formatting:"filler"} & Â
+	{logo_white:"-l -mc=#ffffff -w=~/Pictures/watermark_gray.png"} & Â
+	{logo_white_drop:"-l -d -mc=#ffffff -w=~/Pictures/watermark_gray.png"} & Â
+	{logo_white_pic:"-l -p -mc=#ffffff -w=~/Pictures/watermark_gray.png"} & Â
+	{logo_white_drop_pic:"-l -d -p -mc=#ffffff -w=~/Pictures/watermark_gray.png"} & Â
+	{formatting:"filler"} & Â
+	{logo_gray:"-l -mc=#383838 -w=~/Pictures/watermark_white.png"} & Â
+	{logo_gray_drop:"-l -d -mc=#383838 -w=~/Pictures/watermark_white.png"} & Â
+	{logo_gray_pic:"-l -p -mc=#383838 -w=~/Pictures/watermark_white.png"} & Â
+	{logo_gray_drop_pic:"-l -d -p -mc=#383838 -w=~/Pictures/watermark_white.png"} & Â
+	{formatting:"filler"} & Â
+	{text_over_white:"-ot -mc=#ffffff -g=south -d -tc=#E0E0E0"} & Â
+	{text_over_white_drop:"-ot -d -mc=#ffffff -g=south -d -tc=#E0E0E0"} & Â
+	{text_over_white_pic:"-ot -p -mc=#ffffff -g=south -d -tc=#E0E0E0"} & Â
+	{text_over_white_drop_pic:"-ot -d -p -mc=#ffffff -g=south -d -tc=#E0E0E0"} & Â
+	{formatting:"filler"} & Â
+	{text_over_gray:"-ot -mc=#383838 -g=south -d -tc=#E0E0E0"} & Â
+	{text_over_gray_drop:"-ot -d -mc=#383838 -g=south -d -tc=#E0E0E0"} & Â
+	{text_over_gray_pic:"-ot -p -mc=#383838 -g=south -d -tc=#E0E0E0"} & Â
+	{text_over_gray_drop_pic:"-ot -d -p -mc=#383838 -g=south -d -tc=#E0E0E0"} & Â
+	{formatting:"filler"} & Â
+	{text_white:"-t -mc=#ffffff -tc=#383838"} & Â
+	{text_white_drop:"-t -d -mc=#ffffff -tc=#383838"} & Â
+	{text_white_pic:"-t -p -mc=#ffffff -tc=#383838"} & Â
+	{text_white_drop_pic:"-t -d -p -mc=#ffffff -tc=#383838"} & Â
+	{formatting:"filler"} & Â
+	{text_gray:"-t -mc=#383838 -tc=#E0E0E0"} & Â
+	{text_gray_drop:"-t -d -mc=#383838 -tc=#E0E0E0"} & Â
+	{text_gray_pic:"-t -p -mc=#383838 -tc=#E0E0E0"} & Â
+	{text_gray_drop_pic:"-t -d -p -mc=#383838 -tc=#E0E0E0"}
+
+on sortList(theList)
+	set theIndexList to {}
+	set theSortedList to {}
+	repeat (length of theList) times
+		set theLowItem to ""
+		repeat with a from 1 to (length of theList)
+			if a is not in theIndexList then
+				set theCurrentItem to item a of theList as text
+				if theLowItem is "" then
+					set theLowItem to theCurrentItem
+					set theLowItemIndex to a
+				else if theCurrentItem comes before theLowItem then
+					set theLowItem to theCurrentItem
+					set theLowItemIndex to a
+				end if
+			end if
+		end repeat
+		set end of theSortedList to theLowItem
+		set end of theIndexList to theLowItemIndex
+	end repeat
+	return theSortedList
+end sortList
+
+on run
+	set filler to "formatting"
+	set dropletSource to "logo_white_pic.applescript"
+	
+	set optionsData to my (NSDictionary's dictionaryWithDictionary:optionsList)
+	set listOfDroplets to optionsData's allKeys() as list
+	
+	set listOfDroplets to sortList(listOfDroplets)
+	
+	if listOfDroplets contains filler then
+		set formatting to 0
+		repeat with position from 1 to count of listOfDroplets
+			if item position of listOfDroplets is filler then
+				set formatting to position
+			end if
+		end repeat
+		
+		if formatting is 1 then
+			set listOfDroplets to items 2 thru (count of listOfDroplets) of listOfDroplets
+		end if
+		if formatting is (count of listOfDroplets) then
+			set listOfDroplets to items 1 thru -2 of listOfDroplets
+		end if
+		if formatting is greater than 1 and formatting is less than (count of listOfDroplets) then
+			set listOfDroplets to items 1 thru (formatting - 1) of listOfDroplets & items (formatting + 1) thru (count of listOfDroplets) of listOfDroplets
+		end if
+	end if
+	
+	-- select the droplet folder with Finder
+	set dropletFolder to POSIX path of (choose folder with prompt "Select the folder for your Magick Frames droplets:")
+	
+	set dropletSource to the quoted form of (POSIX path of (choose file with prompt "Select the Magick Frames StyleDroplet script"))
+	
+	set dropletCommands to {}
+	repeat with droplet in listOfDroplets
+		-- set destination droplet
+		set droplet to "'" & dropletFolder & droplet & ".app'"
+		-- set shell command to build droplet
+		set thisDroplet to "osacompile -x -o " & droplet & " " & dropletSource
+		-- execute the shell command to build the droplet
+		try
+			do shell script thisDroplet
+		on error errStr number errorNumber
+			display dialog "Droplet ERROR: " & errStr & ": " & (errorNumber as text) & "on file " & this_filename
+		end try
+	end repeat
+	
+	-- join the list of droplet names on different lines
+	set AppleScript's text item delimiters to "
+"
+	set droplets to listOfDroplets as string
+	set AppleScript's text item delimiters to ""
+	
+	-- tell the user how many droplets were created, where they were created, and their names
+	display dialog "Created " & ((count of listOfDroplets) as string) & " droplets in:
+
+" & dropletFolder & "
+
+" & droplets
+	
+	
+end run

--- a/README.md
+++ b/README.md
@@ -74,10 +74,13 @@ The AppleScript droplet originates from Apple’s Recursive Image File Processin
 
 Below is a list of all the styles included in the script and their options. See the command line section at the bottom for a complete description of all the supported options.
 
-RECOMMENDATION: make two watermark image files on transparent background and place in your Pictures folder:
+RECOMMENDATION: make two watermark image files:
 
-- watermark_light.png (light colored logo for dark matte colors and image areas)
-- watermark_dark.png (dark colored logo for light matte colors and image areas)
+- make them 900 pixels wide and 250 pixel tall
+- make them on transparent background
+- place them in your Pictures folder
+- make a `watermark_light.png` (light colored logo for dark matte colors and image areas)
+- make a `watermark_dark.png` (dark colored logo for light matte colors and image areas)
 
 **NOTE**: the included styles preserve the source image. Edit the StyleDroplet AppleScript and add option `-o` or `--overwrite` to overwrite the source.
 

--- a/README.md
+++ b/README.md
@@ -86,56 +86,56 @@ Below is a list of all the styles included in the script and their options. See 
 - styles with a `watermark_light.png` use a transparent watermark with light logo for dark backgrounds
 - styles with a `watermark_dark.png` use a transparent watermark with dark logo for light backgrounds
 
-### Logo Inside Image, White Background
+### Logo Inside Image, White Background, Light Logo (assumes logo goes in dark image area)
 
-- logo_over_light: -ol -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png
-- logo_over_light_drop: -ol -d -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png
-- logo_over_light_pic: -ol -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png
-- logo_over_light_drop_pic: -ol -d -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png
+- logo_over_light: -ol -mc=#ffffff -g=southeast -w=~/Pictures/watermark_light.png
+- logo_over_light_drop: -ol -d -mc=#ffffff -g=southeast -w=~/Pictures/watermark_light.png
+- logo_over_light_pic: -ol -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_light.png
+- logo_over_light_drop_pic: -ol -d -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_light.png
 
-### Logo Inside Image, Gray Background
+### Logo Inside Image, Gray Background, Light Logo (assumes logo goes in dark image area)
 
 - logo_over_dark: -ol -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png
 - logo_over_dark_drop: -ol -d -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png
 - logo_over_dark_pic: -ol -p -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png
 - logo_over_dark_drop_pic: -ol -d -p -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png
 
-### Logo Below Image, White Background
+### Logo Below Image, White Background, Dark Logo (for light matte color below image)
 
 - logo_light: -l -mc=#ffffff -w=~/Pictures/watermark_dark.png
 - logo_light_drop: -l -d -mc=#ffffff -w=~/Pictures/watermark_dark.png
 - logo_light_pic: -l -p -mc=#ffffff -w=~/Pictures/watermark_dark.png
 - logo_light_drop_pic: -l -d -p -mc=#ffffff -w=~/Pictures/watermark_dark.png
 
-### Logo Below Image, Gray Background
+### Logo Below Image, Gray Background, Light Logo (for dark matte color below image)
 
 - logo_dark: -l -mc=#383838 -w=~/Pictures/watermark_light.png
 - logo_dark_drop: -l -d -mc=#383838 -w=~/Pictures/watermark_light.png
 - logo_dark_pic: -l -p -mc=#383838 -w=~/Pictures/watermark_light.png
 - logo_dark_drop_pic: -l -d -p -mc=#383838 -w=~/Pictures/watermark_light.png
 
-### Text Inside Image, White Background
+### Text Inside Image, White Background, Light Text (assumes text goes in dark image area)
 
 - text_over_light: -ot -mc=#ffffff -g=south -d -tc=#E0E0E0
 - text_over_light_drop: -ot -d -mc=#ffffff -g=south -d -tc=#E0E0E0
 - text_over_light_pic: -ot -p -mc=#ffffff -g=south -d -tc=#E0E0E0
 - text_over_light_drop_pic: -ot -d -p -mc=#ffffff -g=south -d -tc=#E0E0E0
 
-### Text Inside Image, Gray Background
+### Text Inside Image, Gray Background, Light Text (assumes text goes in dark image area)
 
 - text_over_dark: -ot -mc=#383838 -g=south -d -tc=#E0E0E0
 - text_over_dark_drop: -ot -d -mc=#383838 -g=south -d -tc=#E0E0E0
 - text_over_dark_pic: -ot -p -mc=#383838 -g=south -d -tc=#E0E0E0
 - text_over_dark_drop_pic: -ot -d -p -mc=#383838 -g=south -d -tc=#E0E0E0
 
-### Text Below Image, White Background
+### Text Below Image, White Background, Dark Text (for light matte color below image)
 
 - text_light: -t -mc=#ffffff -tc=#383838
 - text_light_drop: -t -d -mc=#ffffff -tc=#383838
 - text_light_pic: -t -p -mc=#ffffff -tc=#383838
 - text_light_drop_pic: -t -d -p -mc=#ffffff -tc=#383838
 
-### Text Below Image, Gray Background
+### Text Below Image, Gray Background, Light Text (for dark matte color below image)
 
 - text_dark: -t -mc=#383838 -tc=#E0E0E0
 - text_dark_drop: -t -d -mc=#383838 -tc=#E0E0E0

--- a/README.md
+++ b/README.md
@@ -169,9 +169,60 @@ Below is a list of all the styles included in the script and their options. See 
 
 ### Create Custom Styles
 
-If you feel comfortable with the AppleScript Script Editor, you can add your own styles to the style list.
+**WARNING**: You MUST use Script Editor to add custom styles. The `styleDroplets` property list uses OPT+[RETURN] to continue the list across multiple lines. Other code editing tools such as Visual Studio Code and Atom are unable to insert this special form of line continuation.
 
-**WARNING**: You MUST use Script Editor to add custom styles. The `styleDroplets` property list uses OPT+[RETURN] to continue the list across multiple lines.
+If you feel comfortable with the AppleScript Script Editor, you can add your own styles to the style list. You will see entries for "formatting". These are simply fillers to make it easier to read and group together the defined styles with similar looks.
+
+The property list uses `key:value` pairs where the style name is the key and the `frame_it` style options is the value. Use `frame_it` from the command line to test different options and develop your own custom style settings. Run `frame_it` with NO options to see a complete list of style options. Once you have an options set you like, add a new entry to the property list with unique name and the options you choose, and export a new droplet named for your custom style(s).
+
+```
+	{your_style_name:"-your -style -options"} & ¬
+```
+
+Below is the `styleDroplets` property list included with package that represents the included styles described above.
+
+```
+property styleDroplets : {formatting:"filler"} & ¬
+	{logo_over_light:"-ol -mc=#ffffff -g=southeast -w=~/Pictures/watermark_light.png"} & ¬
+	{logo_over_light_drop:"-ol -d -mc=#ffffff -g=southeast -w=~/Pictures/watermark_light.png"} & ¬
+	{logo_over_light_pic:"-ol -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_light.png"} & ¬
+	{logo_over_light_drop_pic:"-ol -d -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_light.png"} & ¬
+	{formatting:"filler"} & ¬
+	{logo_over_dark:"-ol -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png"} & ¬
+	{logo_over_dark_drop:"-ol -d -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png"} & ¬
+	{logo_over_dark_pic:"-ol -p -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png"} & ¬
+	{logo_over_dark_drop_pic:"-ol -d -p -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png"} & ¬
+	{formatting:"filler"} & ¬
+	{logo_light:"-l -mc=#ffffff -w=~/Pictures/watermark_dark.png"} & ¬
+	{logo_light_drop:"-l -d -mc=#ffffff -w=~/Pictures/watermark_dark.png"} & ¬
+	{logo_light_pic:"-l -p -mc=#ffffff -w=~/Pictures/watermark_dark.png"} & ¬
+	{logo_light_drop_pic:"-l -d -p -mc=#ffffff -w=~/Pictures/watermark_dark.png"} & ¬
+	{formatting:"filler"} & ¬
+	{logo_dark:"-l -mc=#383838 -w=~/Pictures/watermark_light.png"} & ¬
+	{logo_dark_drop:"-l -d -mc=#383838 -w=~/Pictures/watermark_light.png"} & ¬
+	{logo_dark_pic:"-l -p -mc=#383838 -w=~/Pictures/watermark_light.png"} & ¬
+	{logo_dark_drop_pic:"-l -d -p -mc=#383838 -w=~/Pictures/watermark_light.png"} & ¬
+	{formatting:"filler"} & ¬
+	{text_over_light:"-ot -mc=#ffffff -g=south -d -tc=#E0E0E0"} & ¬
+	{text_over_light_drop:"-ot -d -mc=#ffffff -g=south -d -tc=#E0E0E0"} & ¬
+	{text_over_light_pic:"-ot -p -mc=#ffffff -g=south -d -tc=#E0E0E0"} & ¬
+	{text_over_light_drop_pic:"-ot -d -p -mc=#ffffff -g=south -d -tc=#E0E0E0"} & ¬
+	{formatting:"filler"} & ¬
+	{text_over_dark:"-ot -mc=#383838 -g=south -d -tc=#E0E0E0"} & ¬
+	{text_over_dark_drop:"-ot -d -mc=#383838 -g=south -d -tc=#E0E0E0"} & ¬
+	{text_over_dark_pic:"-ot -p -mc=#383838 -g=south -d -tc=#E0E0E0"} & ¬
+	{text_over_dark_drop_pic:"-ot -d -p -mc=#383838 -g=south -d -tc=#E0E0E0"} & ¬
+	{formatting:"filler"} & ¬
+	{text_light:"-t -mc=#ffffff -tc=#383838"} & ¬
+	{text_light_drop:"-t -d -mc=#ffffff -tc=#383838"} & ¬
+	{text_light_pic:"-t -p -mc=#ffffff -tc=#383838"} & ¬
+	{text_light_drop_pic:"-t -d -p -mc=#ffffff -tc=#383838"} & ¬
+	{formatting:"filler"} & ¬
+	{text_dark:"-t -mc=#383838 -tc=#E0E0E0"} & ¬
+	{text_dark_drop:"-t -d -mc=#383838 -tc=#E0E0E0"} & ¬
+	{text_dark_pic:"-t -p -mc=#383838 -tc=#E0E0E0"} & ¬
+	{text_dark_drop_pic:"-t -d -p -mc=#383838 -tc=#E0E0E0"}
+```
 
 Carefully follow the instructions above the `styleDroplets` style list inside both the StyleDroplet and CreateStyleDroplets scripts. Use the instructions above to create droplets for individual styles for all the styles including your own custom styles. Custom style droplets should produce the same behavior as the included styles.
 

--- a/README.md
+++ b/README.md
@@ -18,12 +18,6 @@ Options for decorating your image and applying text or a logo include:
 
 You can name a default logo file and enter the two-row label text in the script. An alternate logo file can be named on the command line. The two-row label text cannot be overridden on the command line at this time.
 
-Options for the macOS AppleScript droplet include:
-
-- drag-n-drop files onto the droplet using Finder to decorate the selected files
-- double-click the droplet to open a file chooser and decorate the selected files
-- add to an export recipe of an image editing tool to decorate images on export
-
 # What Is Magick Frames
 
 Magick Frames is a combination of a macOS/Linux shell script and a macOS AppleScript droplet. The shell script uses the [ImageMagick](https://imagemagick.org/) image manipulation package to apply a professional looking decoration to a selection of image files.
@@ -55,6 +49,12 @@ Edit the `frame_it` script and look for these lines.
 In the line containing `export`, replace `/path/to/your/imagemagick` with the folder where your ImageMagick tools reside, uncomment the line (remove the `# ` at the beginning), and save the file.
 
 # Creating macOS Droplets
+
+The macOS droplet included with this package creates an app that lets you:
+
+- drag-n-drop files onto the droplet using Finder to decorate the selected files
+- double-click the droplet to open a file chooser and decorate the selected files
+- add to an export recipe of an image editing tool to decorate images on export
 
 The [StyleDroplet](StyleDroplet.applescript) AppleScript is a style droplet that uses the `frame_it` script to decorate your image files. It includes a list of predefined styles. See the names of the included styles in a property called `styleDroplets`. Save the script as an app named for one of the included styles. When the saved droplet runs it looks for its own name in the styles list and uses the options associated with its name. Save as different included style names to create multiple droplets that decorate in different styles.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Edit the `frame_it` script and look for these lines.
 
 In the line containing `export`, replace `/path/to/your/imagemagick` with the folder where your ImageMagick tools reside, uncomment the line (remove the `# ` at the beginning), and save the file.
 
-# Creating The AppleScript Droplet
+# Creating macOS Droplets
 
 The [StyleDroplet](StyleDroplet.applescript) AppleScript is a style droplet that uses the `frame_it` script to decorate your image files. It includes a list of predefined styles. See the names of the included styles in a property called `styleDroplets`. Save the script as an app named for one of the included styles. When the saved droplet runs it looks for its own name in the styles list and uses the options associated with its name. Save as different included style names to create multiple droplets that decorate in different styles.
 
@@ -70,17 +70,20 @@ If you feel comfortable with the AppleScript Script Editor, you can add your own
 
 The AppleScript droplet originates from Apple’s Recursive Image File Processing Droplet template. Find more information in the [Mac Automation Scripting Guide to Process Dropped Files and Folders](https://developer.apple.com/library/content/documentation/LanguagesUtilities/Conceptual/MacAutomationScriptingGuide/ProcessDroppedFilesandFolders.html).
 
+# Logo Watermarks
+
+Make your logo watermark image files with these specifications:
+
+- 900 pixels wide and 250 pixels tall
+- use a transparent background
+- save your logo image files as PNG files
+- place your logos in your Pictures folder
+- make a light colored logo for dark mattes and image areas (`watermark_light.png`)
+- make a dark colored logo for light mattes and image areas (`watermark_dark.png`)
+
 # Included Styles
 
 Below is a list of all the styles included in the script and their options. See the command line section at the bottom for a complete description of all the supported options.
-
-RECOMMENDATION: make two watermark image files:
-
-- make them 900 pixels wide and 250 pixel tall
-- make them on transparent background
-- place them in your Pictures folder
-- make a `watermark_light.png` (light colored logo for dark matte colors and image areas)
-- make a `watermark_dark.png` (dark colored logo for light matte colors and image areas)
 
 **NOTE**: the included styles preserve the source image. Edit the StyleDroplet AppleScript and add option `-o` or `--overwrite` to overwrite the source.
 
@@ -95,56 +98,56 @@ RECOMMENDATION: make two watermark image files:
 - styles with a `watermark_light.png` use a transparent watermark with light logo for dark backgrounds
 - styles with a `watermark_dark.png` use a transparent watermark with dark logo for light backgrounds
 
-### Logo Inside Image, White Background, Light Logo (assumes logo goes in dark image area)
+**Logo Inside Image, White Background, Light Logo (assumes logo goes in dark image area)**
 
 - logo_over_light: -ol -mc=#ffffff -g=southeast -w=~/Pictures/watermark_light.png
 - logo_over_light_drop: -ol -d -mc=#ffffff -g=southeast -w=~/Pictures/watermark_light.png
 - logo_over_light_pic: -ol -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_light.png
 - logo_over_light_drop_pic: -ol -d -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_light.png
 
-### Logo Inside Image, Gray Background, Light Logo (assumes logo goes in dark image area)
+**Logo Inside Image, Gray Background, Light Logo (assumes logo goes in dark image area)**
 
 - logo_over_dark: -ol -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png
 - logo_over_dark_drop: -ol -d -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png
 - logo_over_dark_pic: -ol -p -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png
 - logo_over_dark_drop_pic: -ol -d -p -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png
 
-### Logo Below Image, White Background, Dark Logo (for light matte color below image)
+**Logo Below Image, White Background, Dark Logo (for light matte color below image)**
 
 - logo_light: -l -mc=#ffffff -w=~/Pictures/watermark_dark.png
 - logo_light_drop: -l -d -mc=#ffffff -w=~/Pictures/watermark_dark.png
 - logo_light_pic: -l -p -mc=#ffffff -w=~/Pictures/watermark_dark.png
 - logo_light_drop_pic: -l -d -p -mc=#ffffff -w=~/Pictures/watermark_dark.png
 
-### Logo Below Image, Gray Background, Light Logo (for dark matte color below image)
+**Logo Below Image, Gray Background, Light Logo (for dark matte color below image)**
 
 - logo_dark: -l -mc=#383838 -w=~/Pictures/watermark_light.png
 - logo_dark_drop: -l -d -mc=#383838 -w=~/Pictures/watermark_light.png
 - logo_dark_pic: -l -p -mc=#383838 -w=~/Pictures/watermark_light.png
 - logo_dark_drop_pic: -l -d -p -mc=#383838 -w=~/Pictures/watermark_light.png
 
-### Text Inside Image, White Background, Light Text (assumes text goes in dark image area)
+**Text Inside Image, White Background, Light Text (assumes text goes in dark image area)**
 
 - text_over_light: -ot -mc=#ffffff -g=south -d -tc=#E0E0E0
 - text_over_light_drop: -ot -d -mc=#ffffff -g=south -d -tc=#E0E0E0
 - text_over_light_pic: -ot -p -mc=#ffffff -g=south -d -tc=#E0E0E0
 - text_over_light_drop_pic: -ot -d -p -mc=#ffffff -g=south -d -tc=#E0E0E0
 
-### Text Inside Image, Gray Background, Light Text (assumes text goes in dark image area)
+**Text Inside Image, Gray Background, Light Text (assumes text goes in dark image area)**
 
 - text_over_dark: -ot -mc=#383838 -g=south -d -tc=#E0E0E0
 - text_over_dark_drop: -ot -d -mc=#383838 -g=south -d -tc=#E0E0E0
 - text_over_dark_pic: -ot -p -mc=#383838 -g=south -d -tc=#E0E0E0
 - text_over_dark_drop_pic: -ot -d -p -mc=#383838 -g=south -d -tc=#E0E0E0
 
-### Text Below Image, White Background, Dark Text (for light matte color below image)
+**Text Below Image, White Background, Dark Text (for light matte color below image)**
 
 - text_light: -t -mc=#ffffff -tc=#383838
 - text_light_drop: -t -d -mc=#ffffff -tc=#383838
 - text_light_pic: -t -p -mc=#ffffff -tc=#383838
 - text_light_drop_pic: -t -d -p -mc=#ffffff -tc=#383838
 
-### Text Below Image, Gray Background, Light Text (for dark matte color below image)
+**Text Below Image, Gray Background, Light Text (for dark matte color below image)**
 
 - text_dark: -t -mc=#383838 -tc=#E0E0E0
 - text_dark_drop: -t -d -mc=#383838 -tc=#E0E0E0

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ The AppleScript droplet originates from Apple’s Recursive Image File Processin
 
 Below is a list of all the styles included in the script and their options. See the command line section at the bottom for a complete description of all the supported options.
 
+RECOMMENDATION: make two watermark image files on transparent background and place in your Pictures folder:
+
+- watermark_light.png (light colored logo for dark matte colors and image areas)
+- watermark_dark.png (dark colored logo for light matte colors and image areas)
+
 **NOTE**: the included styles preserve the source image. Edit the StyleDroplet AppleScript and add option `-o` or `--overwrite` to overwrite the source.
 
 - styles with `text` in the name use the two-row text-based labels for watermarking

--- a/README.md
+++ b/README.md
@@ -78,11 +78,12 @@ Below is a list of all the styles included in the script and their options. See 
 
 - styles with `text` in the name use the two-row text-based labels for watermarking
 - styles with `logo` in the name use the image-based logo for watermarking (logo-based is the default)
-- styles with `over` in the name place the text or logo "over" (inside) the image (below the image is the default)
+- styles with `over` in the name place the text or logo "over" (inside) the image (centered below is the default)
 - styles with `drop` in the name use a drop-shadow vs shadow on all edges (all edges is the default)
 - styles with `pic` in the name add the picture frame to the images (no picture frame is the default)
 - styles with `white` in the name use a white background (matte color) (white matte color is the default)
 - styles with `gray` in the name use a gray background (matte color)
+- styles with `-g` use this option to specify placement inside them image (see `gravity` in command line options)
 - styles with a `watermark_light.png` use a transparent watermark with light logo for dark backgrounds
 - styles with a `watermark_dark.png` use a transparent watermark with dark logo for light backgrounds
 

--- a/README.md
+++ b/README.md
@@ -30,12 +30,13 @@ The `frame_it` shell script offers numerous options to tailor the style of the d
 
 # Installation and Configuration
 
+## Install ImageMagick
+
 Installation and use of this package requires saving AppleScript scripts as macOS droplets, installing the open source [ImageMagick](https://imagemagick.org/) software using a tool such as [Home Brew](https://brew.sh/), and using a macOS Terminal or Linux shell window to copy a script to your system's /usr/local/bin directory.
 
-- Install the [ImageMagick](https://imagemagick.org/) software package on your system (e.g. `brew install imagemagick`)
-- Edit the [frame_it](frame_it) shell script and set default label text (`label1`, `label2`) and logo file (`watermark`)
-- Copy the edited [frame_it](frame_it) shell script into your system's /usr/local/bin folder
-- (macOS) Open [logo_light_pic.applescript](logo_light_pic.applescript), and save as a droplet named one of the styles in the `styleDroplets` property list.
+## Configure and Copy `frame_it` Shell Script
+
+Edit the [frame_it](frame_it) shell script and set default label text (`label1`, `label2`) and logo file (`watermark`). Copy the edited [frame_it](frame_it) shell script into your system's /usr/local/bin folder.
 
 Use a Terminal command line to test the `frame_it` script to ensure it can access the ImageMagick tools. If the `frame_it` script says it cannot find the `identify` or `magick` command, this indicates that the folder containing the ImageMagick tools is not in the script’s environment path. Locate the directory where the ImageMagick tools are installed.
 
@@ -48,7 +49,7 @@ Edit the `frame_it` script and look for these lines.
 
 In the line containing `export`, replace `/path/to/your/imagemagick` with the folder where your ImageMagick tools reside, uncomment the line (remove the `# ` at the beginning), and save the file.
 
-# Creating macOS Droplets
+## Create macOS Droplets
 
 The macOS droplet included with this package creates an app that lets you:
 
@@ -70,7 +71,7 @@ If you feel comfortable with the AppleScript Script Editor, you can add your own
 
 The AppleScript droplet originates from Apple’s Recursive Image File Processing Droplet template. Find more information in the [Mac Automation Scripting Guide to Process Dropped Files and Folders](https://developer.apple.com/library/content/documentation/LanguagesUtilities/Conceptual/MacAutomationScriptingGuide/ProcessDroppedFilesandFolders.html).
 
-# Logo Watermarks
+## Create Logo Watermarks
 
 Make your logo watermark image files with these specifications:
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Magick Frames is a combination of a macOS/Linux shell script and a macOS AppleSc
 
 The style droplet only works on macOS. The `frame_it` shell script should work on macOS and Linux.
 
-By default the `frame_it` shell script preserves your input files by creating new output files with `-frame` is inserted  before the extension in the output filename. An input file named `my-image.jpg` will have an output a file named `my-image-frame.jpg`. The output file is always placed in the same folder as the input file.You can tell the shell script to overwrite your input file by adding the `-o` or `--overwrite` option.
+By default the `frame_it` shell script preserves your input files by creating new output files with `-frame` inserted  before the extension in the output filename. An input file named `my-image.jpg` will have an output a file named `my-image-frame.jpg`. The output file is always placed in the same folder as the input file. You can tell the shell script to overwrite your input file by adding the `-o` or `--overwrite` option.
 
 The `frame_it` shell script offers numerous options to tailor the style of the decoration. See the command line options section near the bottom for a detailed descriptione of these options.
 
@@ -37,15 +37,16 @@ Make your logo watermark image files with these specifications:
 - 900 pixels wide and 250 pixels tall
 - use a transparent background
 - save your logo image files as PNG files
-- place your logos in your Pictures folder
 - make a light colored logo for dark mattes and image areas (`watermark_light.png`)
 - make a dark colored logo for light mattes and image areas (`watermark_dark.png`)
+- place your logos in your Pictures folder
+- DEFAULT: the default watermark logo filename in `frame_it` is `~/Pictures/watermark_dark.png`
 
 ## Install ImageMagick
 
 Installation and use of this package requires saving AppleScript scripts as macOS droplets, installing the open source [ImageMagick](https://imagemagick.org/) software using a tool such as [Home Brew](https://brew.sh/), and using a macOS Terminal or Linux shell window to copy a script to your system's /usr/local/bin directory.
 
-## Configure and Copy `frame_it` Shell Script
+## Install The Shell Script
 
 Edit the [frame_it](frame_it) shell script and set default label text (`label1`, `label2`) and logo file (`watermark`). Copy the edited [frame_it](frame_it) shell script into your system's /usr/local/bin folder.
 
@@ -60,15 +61,26 @@ Edit the `frame_it` script and look for these lines.
 
 In the line containing `export`, replace `/path/to/your/imagemagick` with the folder where your ImageMagick tools reside, uncomment the line (remove the `# ` at the beginning), and save the file.
 
-## Create macOS Droplets
+## Create The Style Droplets
 
-The macOS droplet included with this package creates an app that lets you:
+The Style Droplets work on macOS only. Each Style Droplet you create becomes a macOS app that lets you:
 
 - drag-n-drop files onto the droplet using Finder to decorate the selected files
 - double-click the droplet to open a file chooser and decorate the selected files
 - add to an export recipe of an image editing tool to decorate images on export
 
-The [StyleDroplet](StyleDroplet.applescript) AppleScript is a style droplet that uses the `frame_it` script to decorate your image files. It includes a list of predefined styles. See the names of the included styles in a property called `styleDroplets`. Save the script as an app named for one of the included styles. When the saved droplet runs it looks for its own name in the styles list and uses the options associated with its name. Save as different included style names to create multiple droplets that decorate in different styles.
+There are two ways to create the droplets for macOS.
+
+1. Open the StyleDroplet AppleScript file in Script Editor and export as an app.
+1. Open the CreateStyleDroplets AppleScript file in ScriptEditor and run it.
+
+The [StyleDroplet](StyleDroplet.applescript) AppleScript is a style droplet runs the `frame_it` script to decorate your image files. The StyleDroplet AppleScript includes a set of predefined styles. The names of these included styles are in a property list called `styleDroplets`. Export the script in Script Editor as an app named for one of the included styles. 
+
+When the exported droplet runs it looks for its name in the styles property list and runs the `frame_it` script to decorate selected or dropped image files with the associated options for that style. Export the StyleDroplet as different style names from the `styleDroplets` list to create multiple droplets that decorate your images in different styles.
+
+### Export Individual Style Droplets
+
+You can create individual style droplets for only the styles you want to use.
 
 1. Open [StyleDroplet](StyleDroplet.applescript) script in the macOS AppleScript Editor
 1. Look at the `styleDroplets` property of included styles and their associated options
@@ -76,13 +88,13 @@ The [StyleDroplet](StyleDroplet.applescript) AppleScript is a style droplet that
 
 SPEED TIP: Once you create one droplet, use Finder to copy-n-paste as names of other defined styles. This is faster than exporting the script multiple times from the AppleScript Script Editor.
 
-SPEED TIP: Use the [CreateStyleDroplets](CreateStyleDroplets.applescript) AppleScript. It lets you select the folder where you want your droplets to be created and creates a droplet for each of the included styles. When it is finished it opens the selected folder in Finder so you can see all the droplets.
+### Create All Style Droplets
 
-If you feel comfortable with the AppleScript Script Editor, you can add your own styles to the style list. Carefully follow the instructions above the `styleDroplets` style list inside the script. Save the script as a droplet with your custom style name(s) and test it. You should get the same behavior with your custom style as you get with the included styles.
+Use the [CreateStyleDroplets](CreateStyleDroplets.applescript) AppleScript to create style droplets for all of the styles in the `styleDroplets` property list.. It lets you select the folder where you want your droplets to be created and creates a droplet for each of the included styles. When it is finished it opens the selected folder in Finder so you can see all the droplets.
 
 The AppleScript droplet originates from Apple’s Recursive Image File Processing Droplet template. Find more information in the [Mac Automation Scripting Guide to Process Dropped Files and Folders](https://developer.apple.com/library/content/documentation/LanguagesUtilities/Conceptual/MacAutomationScriptingGuide/ProcessDroppedFilesandFolders.html).
 
-# Included Styles
+### Included Styles
 
 Below is a list of all the styles included in the script and their options. See the command line section at the bottom for a complete description of all the supported options.
 
@@ -154,6 +166,14 @@ Below is a list of all the styles included in the script and their options. See 
 - text_dark_drop: -t -d -mc=#383838 -tc=#E0E0E0
 - text_dark_pic: -t -p -mc=#383838 -tc=#E0E0E0
 - text_dark_drop_pic: -t -d -p -mc=#383838 -tc=#E0E0E0
+
+### Create Custom Styles
+
+If you feel comfortable with the AppleScript Script Editor, you can add your own styles to the style list.
+
+**WARNING**: You MUST use Script Editor to add custom styles. The `styleDroplets` property list uses OPT+[RETURN] to continue the list across multiple lines.
+
+Carefully follow the instructions above the `styleDroplets` style list inside both the StyleDroplet and CreateStyleDroplets scripts. Use the instructions above to create droplets for individual styles for all the styles including your own custom styles. Custom style droplets should produce the same behavior as the included styles.
 
 # How To Use
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Installation and use of this package requires saving AppleScript scripts as macO
 - Install the [ImageMagick](https://imagemagick.org/) software package on your system (e.g. `brew install imagemagick`)
 - Edit [frame_it](frame_it) shell script to set default label text (`label1`, `label2`) and your logo file (`watermark`)
 - Copy the edited [frame_it](frame_it) shell script into your system's /usr/local/bin folder
-- (macOS) Open [logo_white_pic.applescript](logo_white_pic.applescript), and save as a droplet named one of the styles in the `optionsList` property list.
+- (macOS) Open [logo_light_pic.applescript](logo_light_pic.applescript), and save as a droplet named one of the styles in the `styleDroplets` property list.
 
 Use a Terminal command line to test the `frame_it` script to ensure it can access the ImageMagick tools. If the `frame_it` script says it cannot find the `identify` or `magick` command, this indicates that the folder containing the ImageMagick tools is not in the script’s environment path. Locate the directory where the ImageMagick tools are installed.
 
@@ -56,77 +56,91 @@ In the line containing `export`, replace `/path/to/your/imagemagick` with the fo
 
 # Creating The AppleScript Droplet
 
-The AppleScript script is distributed as "[logo_white_pic.applescript](logo_white_pic.applescript)". This is the name of one of the included styles. See the names of all the included styles in a property called `optionsList`. Save the script as an app named one of these included styles and images will be decorated with the options associated with the named style. Save the AppleScript as multiple different included style names to create multiple droplets for use.
+The [StyleDroplet](StyleDroplet.applescript) AppleScript is a style droplet that uses the `frame_it` script to decorate your image files. It includes a list of predefined styles. See the names of the included styles in a property called `styleDroplets`. Save the script as an app named for one of the included styles. When the saved droplet runs it looks for its own name in the styles list and uses the options associated with its name. Save as different included style names to create multiple droplets that decorate in different styles.
 
-1. Open [logo_white_pic.applescript](logo_white_pic.applescript) script in the macOS AppleScript Editor
-1. Look at the `optionsList` property of predefined styles and their associated options
+1. Open [StyleDroplet](StyleDroplet.applescript) script in the macOS AppleScript Editor
+1. Look at the `styleDroplets` property of included styles and their associated options
 1. Use File > Export, choose type Application, and save a Droplet as each of your desired style names
 
 SPEED TIP: Once you create one droplet, use Finder to copy-n-paste as names of other defined styles. This is faster than exporting the script multiple times from the AppleScript Script Editor.
 
-If you feel comfortable with the AppleScript Script Editor, you can add your own styles to the style list. Carefully follow the instructions above the `optionsList` style list inside the script. Save the script as a droplet with your custom style name(s) and test it. You should get the same behavior with your custom style as you get with the included styles.
+SPEED TIP: Use the [CreateStyleDroplets](CreateStyleDroplets.applescript) AppleScript. It lets you select the folder where you want your droplets to be created and creates a droplet for each of the included styles. When it is finished it opens the selected folder in Finder so you can see all the droplets.
+
+If you feel comfortable with the AppleScript Script Editor, you can add your own styles to the style list. Carefully follow the instructions above the `styleDroplets` style list inside the script. Save the script as a droplet with your custom style name(s) and test it. You should get the same behavior with your custom style as you get with the included styles.
 
 The AppleScript droplet originates from Apple’s Recursive Image File Processing Droplet template. Find more information in the [Mac Automation Scripting Guide to Process Dropped Files and Folders](https://developer.apple.com/library/content/documentation/LanguagesUtilities/Conceptual/MacAutomationScriptingGuide/ProcessDroppedFilesandFolders.html).
 
+# Included Styles
+
 Below is a list of all the styles included in the script and their options. See the command line section at the bottom for a complete description of all the supported options.
 
-**NOTE**: the predefined styles preserve the source image. Add option `-o` or `--overwrite` to overwrite the source.
+**NOTE**: the included styles preserve the source image. Edit the StyleDroplet AppleScript and add option `-o` or `--overwrite` to overwrite the source.
+
+- styles with `text` in the name use the two-row text-based labels for watermarking
+- styles with `logo` in the name use the image-based logo for watermarking (logo-based is the default)
+- styles with `over` in the name place the text or logo "over" (inside) the image (below the image is the default)
+- styles with `drop` in the name use a drop-shadow vs shadow on all edges (all edges is the default)
+- styles with `pic` in the name add the picture frame to the images (no picture frame is the default)
+- styles with `white` in the name use a white background (matte color) (white matte color is the default)
+- styles with `gray` in the name use a gray background (matte color)
+- styles with a `watermark_light.png` use a transparent watermark with light logo for dark backgrounds
+- styles with a `watermark_dark.png` use a transparent watermark with dark logo for light backgrounds
 
 ### Logo Inside Image, White Background
 
-- logo_over_white: -ol -mc=#ffffff -g=southeast -w=~/Pictures/watermark_white.png
-- logo_over_white_drop: -ol -d -mc=#ffffff -g=southeast -w=~/Pictures/watermark_white.png
-- logo_over_white_pic: -ol -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_white.png
-- logo_over_white_drop_pic: -ol -d -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_white.png
+- logo_over_light: -ol -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png
+- logo_over_light_drop: -ol -d -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png
+- logo_over_light_pic: -ol -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png
+- logo_over_light_drop_pic: -ol -d -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png
 
 ### Logo Inside Image, Gray Background
 
-- logo_over_gray: -ol -mc=#383838 -g=southeast -w=~/Pictures/watermark_white.png
-- logo_over_gray_drop: -ol -d -mc=#383838 -g=southeast -w=~/Pictures/watermark_white.png
-- logo_over_gray_pic: -ol -p -mc=#383838 -g=southeast -w=~/Pictures/watermark_white.png
-- logo_over_gray_drop_pic: -ol -d -p -mc=#383838 -g=southeast -w=~/Pictures/watermark_white.png
+- logo_over_dark: -ol -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png
+- logo_over_dark_drop: -ol -d -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png
+- logo_over_dark_pic: -ol -p -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png
+- logo_over_dark_drop_pic: -ol -d -p -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png
 
 ### Logo Below Image, White Background
 
-- logo_white: -l -mc=#ffffff -w=~/Pictures/watermark_gray.png
-- logo_white_drop: -l -d -mc=#ffffff -w=~/Pictures/watermark_gray.png
-- logo_white_pic: -l -p -mc=#ffffff -w=~/Pictures/watermark_gray.png
-- logo_white_drop_pic: -l -d -p -mc=#ffffff -w=~/Pictures/watermark_gray.png
+- logo_light: -l -mc=#ffffff -w=~/Pictures/watermark_dark.png
+- logo_light_drop: -l -d -mc=#ffffff -w=~/Pictures/watermark_dark.png
+- logo_light_pic: -l -p -mc=#ffffff -w=~/Pictures/watermark_dark.png
+- logo_light_drop_pic: -l -d -p -mc=#ffffff -w=~/Pictures/watermark_dark.png
 
 ### Logo Below Image, Gray Background
 
-- logo_gray: -l -mc=#383838 -w=~/Pictures/watermark_white.png
-- logo_gray_drop: -l -d -mc=#383838 -w=~/Pictures/watermark_white.png
-- logo_gray_pic: -l -p -mc=#383838 -w=~/Pictures/watermark_white.png
-- logo_gray_drop_pic: -l -d -p -mc=#383838 -w=~/Pictures/watermark_white.png
+- logo_dark: -l -mc=#383838 -w=~/Pictures/watermark_light.png
+- logo_dark_drop: -l -d -mc=#383838 -w=~/Pictures/watermark_light.png
+- logo_dark_pic: -l -p -mc=#383838 -w=~/Pictures/watermark_light.png
+- logo_dark_drop_pic: -l -d -p -mc=#383838 -w=~/Pictures/watermark_light.png
 
 ### Text Inside Image, White Background
 
-- text_over_white: -ot -mc=#ffffff -g=south -d -tc=#E0E0E0
-- text_over_white_drop: -ot -d -mc=#ffffff -g=south -d -tc=#E0E0E0
-- text_over_white_pic: -ot -p -mc=#ffffff -g=south -d -tc=#E0E0E0
-- text_over_white_drop_pic: -ot -d -p -mc=#ffffff -g=south -d -tc=#E0E0E0
+- text_over_light: -ot -mc=#ffffff -g=south -d -tc=#E0E0E0
+- text_over_light_drop: -ot -d -mc=#ffffff -g=south -d -tc=#E0E0E0
+- text_over_light_pic: -ot -p -mc=#ffffff -g=south -d -tc=#E0E0E0
+- text_over_light_drop_pic: -ot -d -p -mc=#ffffff -g=south -d -tc=#E0E0E0
 
 ### Text Inside Image, Gray Background
 
-- text_over_gray: -ot -mc=#383838 -g=south -d -tc=#E0E0E0
-- text_over_gray_drop: -ot -d -mc=#383838 -g=south -d -tc=#E0E0E0
-- text_over_gray_pic: -ot -p -mc=#383838 -g=south -d -tc=#E0E0E0
-- text_over_gray_drop_pic: -ot -d -p -mc=#383838 -g=south -d -tc=#E0E0E0
+- text_over_dark: -ot -mc=#383838 -g=south -d -tc=#E0E0E0
+- text_over_dark_drop: -ot -d -mc=#383838 -g=south -d -tc=#E0E0E0
+- text_over_dark_pic: -ot -p -mc=#383838 -g=south -d -tc=#E0E0E0
+- text_over_dark_drop_pic: -ot -d -p -mc=#383838 -g=south -d -tc=#E0E0E0
 
 ### Text Below Image, White Background
 
-- text_white: -t -mc=#ffffff -tc=#383838
-- text_white_drop: -t -d -mc=#ffffff -tc=#383838
-- text_white_pic: -t -p -mc=#ffffff -tc=#383838
-- text_white_drop_pic: -t -d -p -mc=#ffffff -tc=#383838
+- text_light: -t -mc=#ffffff -tc=#383838
+- text_light_drop: -t -d -mc=#ffffff -tc=#383838
+- text_light_pic: -t -p -mc=#ffffff -tc=#383838
+- text_light_drop_pic: -t -d -p -mc=#ffffff -tc=#383838
 
 ### Text Below Image, Gray Background
 
-- text_gray: -t -mc=#383838 -tc=#E0E0E0
-- text_gray_drop: -t -d -mc=#383838 -tc=#E0E0E0
-- text_gray_pic: -t -p -mc=#383838 -tc=#E0E0E0
-- text_gray_drop_pic: -t -d -p -mc=#383838 -tc=#E0E0E0
+- text_dark: -t -mc=#383838 -tc=#E0E0E0
+- text_dark_drop: -t -d -mc=#383838 -tc=#E0E0E0
+- text_dark_pic: -t -p -mc=#383838 -tc=#E0E0E0
+- text_dark_drop_pic: -t -d -p -mc=#383838 -tc=#E0E0E0
 
 # How To Use
 

--- a/README.md
+++ b/README.md
@@ -16,24 +16,24 @@ Options for decorating your image and applying text or a logo include:
 - choose the font of the text-based label added to the output file
 - choose an alternate logo watermark file on the command line
 
-You can name a default logo file and enter the two-row label text in the script. An alternate logo file can be named on the command line. The two-row label text cannot be overridden on the command line at this time.
+You must name a default logo file and enter the two-row label text in the `frame_it` shell script. You can specify an alternate logo file on the command line or in different macOS droplet styles. The two-row label text cannot be overridden on the command line at this time.
 
 # What Is Magick Frames
 
 Magick Frames is a combination of a macOS/Linux shell script and a macOS AppleScript droplet. The shell script uses the [ImageMagick](https://imagemagick.org/) image manipulation package to apply a professional looking decoration to a selection of image files.
 
+The style droplet only works on macOS. The `frame_it` shell script should work on macOS and Linux.
+
 By default the `frame_it` shell script preserves your input files by creating new output files with `-frame` is inserted  before the extension in the output filename. An input file named `my-image.jpg` will have an output a file named `my-image-frame.jpg`. The output file is always placed in the same folder as the input file.You can tell the shell script to overwrite your input file by adding the `-o` or `--overwrite` option.
 
-The AppleScript droplet only works on macOS. The frame\_it shell script should work on macOS and Linux.
+The `frame_it` shell script offers numerous options to tailor the style of the decoration. See the command line options section near the bottom for a detailed descriptione of these options.
 
-The frame\_it shell script offers numerous options to tailor the style of the decoration. See the command line options section near the bottom for a detailed descriptione of these options.
-
-# Installation
+# Installation and Configuration
 
 Installation and use of this package requires saving AppleScript scripts as macOS droplets, installing the open source [ImageMagick](https://imagemagick.org/) software using a tool such as [Home Brew](https://brew.sh/), and using a macOS Terminal or Linux shell window to copy a script to your system's /usr/local/bin directory.
 
 - Install the [ImageMagick](https://imagemagick.org/) software package on your system (e.g. `brew install imagemagick`)
-- Edit [frame_it](frame_it) shell script to set default label text (`label1`, `label2`) and your logo file (`watermark`)
+- Edit the [frame_it](frame_it) shell script and set default label text (`label1`, `label2`) and logo file (`watermark`)
 - Copy the edited [frame_it](frame_it) shell script into your system's /usr/local/bin folder
 - (macOS) Open [logo_light_pic.applescript](logo_light_pic.applescript), and save as a droplet named one of the styles in the `styleDroplets` property list.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ The `frame_it` shell script offers numerous options to tailor the style of the d
 
 # Installation and Configuration
 
+## Create Logo Watermarks
+
+Make your logo watermark image files with these specifications:
+
+- 900 pixels wide and 250 pixels tall
+- use a transparent background
+- save your logo image files as PNG files
+- place your logos in your Pictures folder
+- make a light colored logo for dark mattes and image areas (`watermark_light.png`)
+- make a dark colored logo for light mattes and image areas (`watermark_dark.png`)
+
 ## Install ImageMagick
 
 Installation and use of this package requires saving AppleScript scripts as macOS droplets, installing the open source [ImageMagick](https://imagemagick.org/) software using a tool such as [Home Brew](https://brew.sh/), and using a macOS Terminal or Linux shell window to copy a script to your system's /usr/local/bin directory.
@@ -70,17 +81,6 @@ SPEED TIP: Use the [CreateStyleDroplets](CreateStyleDroplets.applescript) AppleS
 If you feel comfortable with the AppleScript Script Editor, you can add your own styles to the style list. Carefully follow the instructions above the `styleDroplets` style list inside the script. Save the script as a droplet with your custom style name(s) and test it. You should get the same behavior with your custom style as you get with the included styles.
 
 The AppleScript droplet originates from Apple’s Recursive Image File Processing Droplet template. Find more information in the [Mac Automation Scripting Guide to Process Dropped Files and Folders](https://developer.apple.com/library/content/documentation/LanguagesUtilities/Conceptual/MacAutomationScriptingGuide/ProcessDroppedFilesandFolders.html).
-
-## Create Logo Watermarks
-
-Make your logo watermark image files with these specifications:
-
-- 900 pixels wide and 250 pixels tall
-- use a transparent background
-- save your logo image files as PNG files
-- place your logos in your Pictures folder
-- make a light colored logo for dark mattes and image areas (`watermark_light.png`)
-- make a dark colored logo for light mattes and image areas (`watermark_dark.png`)
 
 # Included Styles
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,13 @@ The property list uses `key:value` pairs where the style name is the key and the
 	{your_style_name:"-your -style -options"} & ¬
 ```
 
-Below is the `styleDroplets` property list included with package that represents the included styles described above.
+Suppose your drop files onto or double-click the `logo_over_dark_drop` droplet. The droplet will construct a separate shell command line for each image file as follows:
+
+```text
+frame_it -ol -d -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png <your image file>
+```
+
+This is the `styleDroplets` property list included with `StyleDroplet` and `CreateStyleDroplets` scripts that represent all of the included styles described above.
 
 ```
 property styleDroplets : {formatting:"filler"} & ¬

--- a/StyleDroplet.applescript
+++ b/StyleDroplet.applescript
@@ -95,10 +95,10 @@ property typeIDs_list : {"public.jpeg", "public.tiff", "public.png", "com.adobe.
 -- CRITICAL -- continued lines must end with ampersand plus OPT+RETURN
 --
 property styleDroplets : {formatting:"filler"} & Â
-	{logo_over_light:"-ol -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png"} & Â
-	{logo_over_light_drop:"-ol -d -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png"} & Â
-	{logo_over_light_pic:"-ol -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png"} & Â
-	{logo_over_light_drop_pic:"-ol -d -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png"} & Â
+	{logo_over_light:"-ol -mc=#ffffff -g=southeast -w=~/Pictures/watermark_light.png"} & Â
+	{logo_over_light_drop:"-ol -d -mc=#ffffff -g=southeast -w=~/Pictures/watermark_light.png"} & Â
+	{logo_over_light_pic:"-ol -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_light.png"} & Â
+	{logo_over_light_drop_pic:"-ol -d -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_light.png"} & Â
 	{formatting:"filler"} & Â
 	{logo_over_dark:"-ol -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png"} & Â
 	{logo_over_dark_drop:"-ol -d -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png"} & Â

--- a/StyleDroplet.applescript
+++ b/StyleDroplet.applescript
@@ -1,37 +1,21 @@
 (*
+
   Original: Walter Rowe in 2022
 
-  The application you create from this AppleScript can be used directly in Finder via drag-n-drop.
-  Select a number of image files, and drag-n-drop them on the application. It will decorate the
-  dropped files.
+  The droplet you create from this AppleScript can be used via drag-n-drop in Finder, as a
+  double-clicked app to choose files to decorate, and as a named app in an export
+  configuration in image editing tools.
 
-  Modifying The Frame Style:
-  * Look below for the variable "frame_it_options" to change the command line options
-  * Look in the frame_it shell script to see the options available styling your images
-  * Remove the "-o" option to create NEW files with "-frame" inserted before extension.
-    * example: my_image.jpg -> my_image-frame.jpg
+  Modifying The Styles List:
+  * Look below for the property "styleDroplets" to create additional styles for droplets
+  * Read the frame_it shell script to see the options available for styling your images
+  * The included styles create NEW files with "-frame" inserted before extension
+    * example: my-image.jpg -> my-image-frame.jpg
 
-  You can set different options and export this as different applications. I have three
-  different exported versions of this. One creates a text-based label, one creates a logo
-  based label, and another applies a watermark ON the image itself.
+  Use the CreateStyleDroplets script to create droplets for all the included styles.
 
-  Package Requirements:
-  * The frame_it shell script only supports macOS and Linux
-  * The frame_it AppleScript only supports macOS
-  * Install ImageMagick using Home Brew or Linux package manager
-  * Copy the frame_it shell script into your /usr/local/bin directory
-  * Edit the frame_it shell script and set the value for "logo" to your logo file
-  * Edit the frame_it shell script and set the value for "label1" and "label2"
+  See the README.md markdown file for detailed instructions on installation and use
 
-  Droplet App Installation:
-  * Open this in AppleScript Editor and File > Export as an Application
-  * OPTION: Add the application to the Open With field of a Capture One Export Recipe
-
-  To see the origins of this script
-  1) open Script Editor
-  2) File > New from Template > Droplets > Recursive Image File Processing Droplet
-
-  https://developer.apple.com/library/content/documentation/LanguagesUtilities/Conceptual/MacAutomationScriptingGuide/ProcessDroppedFilesandFolders.html
 *)
 
 use AppleScript version "2.7"
@@ -109,49 +93,50 @@ property typeIDs_list : {"public.jpeg", "public.tiff", "public.png", "com.adobe.
 -- you can add your own app names and options, and save as your new app name to use your chosen options
 --
 -- CRITICAL -- continued lines must end with ampersand plus OPT+RETURN
-property optionsList : {formatting:"filler"} & Â
-	{logo_over_white:"-ol -mc=#ffffff -g=southeast -w=~/Pictures/watermark_white.png"} & Â
-	{logo_over_white_drop:"-ol -d -mc=#ffffff -g=southeast -w=~/Pictures/watermark_white.png"} & Â
-	{logo_over_white_pic:"-ol -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_white.png"} & Â
-	{logo_over_white_drop_pic:"-ol -d -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_white.png"} & Â
+--
+property styleDroplets : {formatting:"filler"} & Â
+	{logo_over_light:"-ol -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png"} & Â
+	{logo_over_light_drop:"-ol -d -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png"} & Â
+	{logo_over_light_pic:"-ol -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png"} & Â
+	{logo_over_light_drop_pic:"-ol -d -p -mc=#ffffff -g=southeast -w=~/Pictures/watermark_dark.png"} & Â
 	{formatting:"filler"} & Â
-	{logo_over_gray:"-ol -mc=#383838 -g=southeast -w=~/Pictures/watermark_white.png"} & Â
-	{logo_over_gray_drop:"-ol -d -mc=#383838 -g=southeast -w=~/Pictures/watermark_white.png"} & Â
-	{logo_over_gray_pic:"-ol -p -mc=#383838 -g=southeast -w=~/Pictures/watermark_white.png"} & Â
-	{logo_over_gray_drop_pic:"-ol -d -p -mc=#383838 -g=southeast -w=~/Pictures/watermark_white.png"} & Â
+	{logo_over_dark:"-ol -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png"} & Â
+	{logo_over_dark_drop:"-ol -d -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png"} & Â
+	{logo_over_dark_pic:"-ol -p -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png"} & Â
+	{logo_over_dark_drop_pic:"-ol -d -p -mc=#383838 -g=southeast -w=~/Pictures/watermark_light.png"} & Â
 	{formatting:"filler"} & Â
-	{logo_white:"-l -mc=#ffffff -w=~/Pictures/watermark_gray.png"} & Â
-	{logo_white_drop:"-l -d -mc=#ffffff -w=~/Pictures/watermark_gray.png"} & Â
-	{logo_white_pic:"-l -p -mc=#ffffff -w=~/Pictures/watermark_gray.png"} & Â
-	{logo_white_drop_pic:"-l -d -p -mc=#ffffff -w=~/Pictures/watermark_gray.png"} & Â
+	{logo_light:"-l -mc=#ffffff -w=~/Pictures/watermark_dark.png"} & Â
+	{logo_light_drop:"-l -d -mc=#ffffff -w=~/Pictures/watermark_dark.png"} & Â
+	{logo_light_pic:"-l -p -mc=#ffffff -w=~/Pictures/watermark_dark.png"} & Â
+	{logo_light_drop_pic:"-l -d -p -mc=#ffffff -w=~/Pictures/watermark_dark.png"} & Â
 	{formatting:"filler"} & Â
-	{logo_gray:"-l -mc=#383838 -w=~/Pictures/watermark_white.png"} & Â
-	{logo_gray_drop:"-l -d -mc=#383838 -w=~/Pictures/watermark_white.png"} & Â
-	{logo_gray_pic:"-l -p -mc=#383838 -w=~/Pictures/watermark_white.png"} & Â
-	{logo_gray_drop_pic:"-l -d -p -mc=#383838 -w=~/Pictures/watermark_white.png"} & Â
+	{logo_dark:"-l -mc=#383838 -w=~/Pictures/watermark_light.png"} & Â
+	{logo_dark_drop:"-l -d -mc=#383838 -w=~/Pictures/watermark_light.png"} & Â
+	{logo_dark_pic:"-l -p -mc=#383838 -w=~/Pictures/watermark_light.png"} & Â
+	{logo_dark_drop_pic:"-l -d -p -mc=#383838 -w=~/Pictures/watermark_light.png"} & Â
 	{formatting:"filler"} & Â
-	{text_over_white:"-ot -mc=#ffffff -g=south -d -tc=#E0E0E0"} & Â
-	{text_over_white_drop:"-ot -d -mc=#ffffff -g=south -d -tc=#E0E0E0"} & Â
-	{text_over_white_pic:"-ot -p -mc=#ffffff -g=south -d -tc=#E0E0E0"} & Â
-	{text_over_white_drop_pic:"-ot -d -p -mc=#ffffff -g=south -d -tc=#E0E0E0"} & Â
+	{text_over_light:"-ot -mc=#ffffff -g=south -d -tc=#E0E0E0"} & Â
+	{text_over_light_drop:"-ot -d -mc=#ffffff -g=south -d -tc=#E0E0E0"} & Â
+	{text_over_light_pic:"-ot -p -mc=#ffffff -g=south -d -tc=#E0E0E0"} & Â
+	{text_over_light_drop_pic:"-ot -d -p -mc=#ffffff -g=south -d -tc=#E0E0E0"} & Â
 	{formatting:"filler"} & Â
-	{text_over_gray:"-ot -mc=#383838 -g=south -d -tc=#E0E0E0"} & Â
-	{text_over_gray_drop:"-ot -d -mc=#383838 -g=south -d -tc=#E0E0E0"} & Â
-	{text_over_gray_pic:"-ot -p -mc=#383838 -g=south -d -tc=#E0E0E0"} & Â
-	{text_over_gray_drop_pic:"-ot -d -p -mc=#383838 -g=south -d -tc=#E0E0E0"} & Â
+	{text_over_dark:"-ot -mc=#383838 -g=south -d -tc=#E0E0E0"} & Â
+	{text_over_dark_drop:"-ot -d -mc=#383838 -g=south -d -tc=#E0E0E0"} & Â
+	{text_over_dark_pic:"-ot -p -mc=#383838 -g=south -d -tc=#E0E0E0"} & Â
+	{text_over_dark_drop_pic:"-ot -d -p -mc=#383838 -g=south -d -tc=#E0E0E0"} & Â
 	{formatting:"filler"} & Â
-	{text_white:"-t -mc=#ffffff -tc=#383838"} & Â
-	{text_white_drop:"-t -d -mc=#ffffff -tc=#383838"} & Â
-	{text_white_pic:"-t -p -mc=#ffffff -tc=#383838"} & Â
-	{text_white_drop_pic:"-t -d -p -mc=#ffffff -tc=#383838"} & Â
+	{text_light:"-t -mc=#ffffff -tc=#383838"} & Â
+	{text_light_drop:"-t -d -mc=#ffffff -tc=#383838"} & Â
+	{text_light_pic:"-t -p -mc=#ffffff -tc=#383838"} & Â
+	{text_light_drop_pic:"-t -d -p -mc=#ffffff -tc=#383838"} & Â
 	{formatting:"filler"} & Â
-	{text_gray:"-t -mc=#383838 -tc=#E0E0E0"} & Â
-	{text_gray_drop:"-t -d -mc=#383838 -tc=#E0E0E0"} & Â
-	{text_gray_pic:"-t -p -mc=#383838 -tc=#E0E0E0"} & Â
-	{text_gray_drop_pic:"-t -d -p -mc=#383838 -tc=#E0E0E0"}
+	{text_dark:"-t -mc=#383838 -tc=#E0E0E0"} & Â
+	{text_dark_drop:"-t -d -mc=#383838 -tc=#E0E0E0"} & Â
+	{text_dark_pic:"-t -p -mc=#383838 -tc=#E0E0E0"} & Â
+	{text_dark_drop_pic:"-t -d -p -mc=#383838 -tc=#E0E0E0"}
 
 on get_options(appName)
-	set optionsData to my (NSDictionary's dictionaryWithDictionary:optionsList)
+	set optionsData to my (NSDictionary's dictionaryWithDictionary:styleDroplets)
 	set optionsKeys to optionsData's allKeys() as list
 	if optionsKeys contains appName then
 		set appOptions to optionsData's valueForKey:(appName as text)
@@ -172,7 +157,8 @@ end splitText
 on run
 	-- convert "path:to:me.app:" into "me" (apps are folders so note the trailing colon thus the -2 below)
 	set appPath to path to me as string
-	set appName to item -2 of splitText(appPath, ":")
+	set appName to item -1 of splitText(appPath, ":")
+	if appName is "" then set appName to item -2 of splitText(appPath, ":")
 	set appBase to item 1 of splitText(appName, ".")
 	
 	-- get desired frame_it options based on invoked app name
@@ -181,20 +167,28 @@ on run
 	-- app was run from Finder via double-click so pop up file chooser
 	set selected_items to choose file with prompt "Select the images to decorate:" of type {"public.image"} with multiple selections allowed
 	
-	process_items(selected_items, frame_it_options)
+	if frame_it_options is false then
+		display alert "No defined style '" & appBase & "'"
+	else
+		process_items(selected_items, frame_it_options)
+	end if
 end run
 
 -- on open event processes items dropped onto it or sent to it via open app with parameters
 on open dropped_items
 	-- convert "path:to:me.app:" into "me" (note the trailing colon this -2 below)
 	set appPath to path to me as string
-	set appName to item -2 of splitText(appPath, ":")
+	set appName to item -1 of splitText(appPath, ":")
+	if appName is "" then set appName to item -2 of splitText(appPath, ":")
 	set appBase to item 1 of splitText(appName, ".")
 	
 	-- get desired frame_it options based on invoked app name
 	set frame_it_options to get_options(appBase)
-	
-	process_items(dropped_items, frame_it_options)
+	if frame_it_options is false then
+		display alert "No defined style '" & appBase & "'"
+	else
+		process_items(dropped_items, frame_it_options)
+	end if
 end open
 
 on process_items(the_items, frame_it_options)

--- a/StyleDroplet.applescript
+++ b/StyleDroplet.applescript
@@ -1,14 +1,9 @@
 (*
   Original: Walter Rowe in 2022
 
-  2017: ported to latest Capture One and macOS version, modified border styling
-  2022: copied to 'frame_it' and modified to use frame_it (script that uses the ImageMagick Suite vs sips)
-
   The application you create from this AppleScript can be used directly in Finder via drag-n-drop.
   Select a number of image files, and drag-n-drop them on the application. It will decorate the
   dropped files.
-
-  WARNING: the default configuration below OVERWRITES the source files sent to it.
 
   Modifying The Frame Style:
   * Look below for the variable "frame_it_options" to change the command line options

--- a/frame_it
+++ b/frame_it
@@ -67,7 +67,7 @@ label1="W  A  L  T  E  R     R  O  W  E     P  H  O  T  O  G  R  A  P  H  Y"
 label2="w w w . w a l t e r r o w e . c o m"
 
 # default logo watermark file - graphic watermark (my logo watermark is 900wx250h pixels w/ transparent background)
-watermark=~/Pictures/watermark_gray.png
+watermark=~/Pictures/watermark_dark.png
 
 # homebrew on the Apple ARM platform installs apps in /opt/homebrew/bin
 if [ -x /opt/homebrew/bin/brew ]; then

--- a/frame_it
+++ b/frame_it
@@ -354,7 +354,7 @@ for filename in "$@" ; do
     case ${style} in
         text)
             # convert source file into decorated target file
-            magick "${source}" \
+            magick "${source}" -auto-orient \
               -mattecolor black -frame ${inner} -mattecolor white -frame ${outer} \
               \( +clone -background black -shadow ${shadow}${offset} \) \
               +swap -background ${mattecolor} -layers merge +repage \
@@ -368,7 +368,7 @@ for filename in "$@" ; do
 
         overlay_text)
             # convert source file into decorated target file
-            magick "${source}" \
+            magick "${source}" -auto-orient \
               -background transparent -fill "${overlaytextcolor}" -font "${textfont}" -pointsize ${font_pnts} label:"${label1}" -gravity ${logo_gravity} -geometry ${label1_inset} -composite \
               -background transparent -fill "${overlaytextcolor}" -font "${textfont}" -pointsize ${font_pnts} label:"${label2}" -gravity ${logo_gravity} -geometry ${label2_inset} -composite \
               -mattecolor black -frame ${inner} -mattecolor white -frame ${outer} \
@@ -382,7 +382,7 @@ for filename in "$@" ; do
 
         logo)
             # convert source file into decorated target file
-            magick "${source}" \
+            magick "${source}" -auto-orient \
               -mattecolor black -frame ${inner} -mattecolor white -frame ${outer} \
               \( +clone -background black -shadow ${shadow}${offset} \) \
               +swap -background ${mattecolor} -layers merge +repage \
@@ -396,7 +396,7 @@ for filename in "$@" ; do
 
         overlay_logo)
             # convert source file into decorated target file
-            magick "${source}" \
+            magick "${source}" -auto-orient \
               \( ${watermark} -resize ${scaled_logo_wide}x${scaled_logo_high}\> -gravity ${logo_gravity} -geometry ${logo_inset} \) -composite \
               -mattecolor black -frame ${inner} -mattecolor white -frame ${outer} \
               \( +clone -background black -shadow ${shadow}${offset} \) \


### PR DESCRIPTION
Add applescript to create defined style droplets

- update README with instructions
- rename droplet script to StyleDroplet
- create CreateStyleDroplets script
    - choose folder for created droplets
    - choose source droplet script
    - create droplets in selected folder
    - show progress bar while creating
    - notify how many droplets created
    - open droplets folder with Finder

See [Mac Automation Scripting Guide - Display Progress](https://developer.apple.com/library/archive/documentation/LanguagesUtilities/Conceptual/MacAutomationScriptingGuide/DisplayProgress.html).